### PR TITLE
Add automated release workflow for main merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace artifacts
+        run: npm run build
+
+      - name: Package distributables
+        run: |
+          mkdir -p release
+          tar -czf release/crocdesk-server-dist.tar.gz -C apps/server dist
+          tar -czf release/crocdesk-web-dist.tar.gz -C apps/web dist
+          tar -czf release/crocdesk-desktop-dist.tar.gz -C apps/desktop dist
+          cp README.md release/README.md
+          cp CHANGELOG.md release/CHANGELOG.md
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ github.run_number }}
+          name: CrocDesk release ${{ github.run_number }}
+          bodyFile: CHANGELOG.md
+          artifacts: release/*
+          artifactContentType: application/gzip
+          allowUpdates: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+- Automated releases on merges to `main` publish built artifacts and documentation assets.
+- Documented repository structure and development commands.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# CrocDesk
+
+CrocDesk is a desktop ROM library manager built as an Electron shell that serves a React UI over an Express API. The project ships server and desktop runtimes together with a web frontend so you can manage and launch ROMs through a single experience.
+
+## Project structure
+- `apps/server`: Express API, job orchestration, Crocdb client
+- `apps/web`: React UI (Vite)
+- `apps/desktop`: Electron main process
+- `packages/shared`: Shared types, defaults, and manifest schema
+
+## Development
+- Install dependencies with `npm ci`
+- Run `npm run dev` to start the shared build watcher, server, web, and desktop processes together
+- Individual dev servers: `npm run dev:server`, `npm run dev:web`, `npm run dev:desktop`
+- Build all workspaces with `npm run build`
+- Type-check all workspaces with `npm run typecheck`
+
+## Release automation
+Merges to the `main` branch automatically build the server, web, and desktop bundles, archive the distributable outputs, and publish them as GitHub release assets alongside the current changelog and README.


### PR DESCRIPTION
## Summary
- add a release workflow that runs on main merges or manual triggers
- build and package server, web, and desktop distributables for GitHub releases alongside documentation files
- document the project layout and release automation in new README and changelog files

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947e1dffe988328980b51f7e501de0d)