### PR TITLE
Add library view for downloads and owned items

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import BrowsePage from "./pages/BrowsePage";
 import QueuePage from "./pages/QueuePage";
 import SettingsPage from "./pages/SettingsPage";
 import GameDetailPage from "./pages/GameDetailPage";
+import LibraryPage from "./pages/LibraryPage";
 // useMemo imported above
 
 function AppRoutes() {
@@ -15,6 +16,7 @@ function AppRoutes() {
     <>
       <Routes location={baseLocation}>
         <Route path="/" element={<BrowsePage />} />
+        <Route path="/library" element={<LibraryPage />} />
         <Route path="/queue" element={<QueuePage />} />
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/game/:slug" element={<GameDetailPage />} />
@@ -85,6 +87,9 @@ export default function App() {
           <nav className="nav">
             <NavLink to="/" end className={navLinkClass}>
               Browse
+            </NavLink>
+            <NavLink to="/library" className={navLinkClass}>
+              Library
             </NavLink>
             <NavLink to="/queue" className={navLinkClass}>
               Queue

--- a/apps/web/src/pages/LibraryPage.tsx
+++ b/apps/web/src/pages/LibraryPage.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import type { LibraryItem, JobEvent } from "@crocdesk/shared";
+import PlatformIcon from "../components/PlatformIcon";
+import { API_URL, apiGet } from "../lib/api";
+import type { JobWithPreview } from "../types";
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+}
+
+export default function LibraryPage() {
+  const queryClient = useQueryClient();
+  const [jobProgress, setJobProgress] = useState<Record<string, number>>({});
+
+  const libraryQuery = useQuery({
+    queryKey: ["library-items"],
+    queryFn: () => apiGet<LibraryItem[]>("/library/items")
+  });
+
+  const jobsQuery = useQuery({
+    queryKey: ["jobs"],
+    queryFn: () => apiGet<JobWithPreview[]>("/jobs")
+  });
+
+  useEffect(() => {
+    const source = new EventSource(`${API_URL}/events`);
+    source.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as JobEvent;
+        if (typeof data.progress === "number") {
+          setJobProgress((prev) => ({ ...prev, [data.jobId]: data.progress }));
+        }
+        queryClient.invalidateQueries({ queryKey: ["jobs"] });
+        queryClient.invalidateQueries({ queryKey: ["library-items"] });
+      } catch {
+        // Ignore malformed SSE payloads.
+      }
+    };
+
+    return () => source.close();
+  }, [queryClient]);
+
+  const downloadingJobs = useMemo(
+    () =>
+      (jobsQuery.data ?? []).filter(
+        (job) =>
+          job.type === "download_and_install" &&
+          (job.status === "queued" || job.status === "running")
+      ),
+    [jobsQuery.data]
+  );
+
+  const libraryItems = useMemo(() => {
+    return (libraryQuery.data ?? []).slice().sort((a, b) => {
+      const platformA = a.platform ?? "";
+      const platformB = b.platform ?? "";
+      if (platformA === platformB) {
+        return a.path.localeCompare(b.path);
+      }
+      return platformA.localeCompare(platformB);
+    });
+  }, [libraryQuery.data]);
+
+  return (
+    <div className="grid" style={{ gap: "20px" }}>
+      <section className="hero">
+        <h1>Library</h1>
+        <p>See everything you own and track downloads in progress.</p>
+      </section>
+
+      <section className="card">
+        <div className="row">
+          <h3>Downloading</h3>
+          <span className="status">
+            {downloadingJobs.length ? `${downloadingJobs.length} active` : "No active downloads"}
+          </span>
+        </div>
+        <div className="list">
+          {downloadingJobs.length === 0 && (
+            <div className="status">No downloads are running right now.</div>
+          )}
+          {downloadingJobs.map((job) => {
+            const progress = jobProgress[job.id] ?? (job.status === "running" ? 0 : undefined);
+            return (
+              <article className="card" key={job.id}>
+                {job.preview && (
+                  <div className="thumb-wrapper" style={{ float: "right", marginLeft: "12px", maxWidth: "140px" }}>
+                    {job.preview.boxart_url ? (
+                      <img
+                        src={job.preview.boxart_url}
+                        alt={`${job.preview.title} cover art`}
+                        className="thumb"
+                        loading="lazy"
+                        style={{ width: "100%", aspectRatio: "3 / 4", objectFit: "cover", borderRadius: "8px" }}
+                      />
+                    ) : (
+                      <div className="thumb-placeholder">
+                        <PlatformIcon platform={job.preview.platform} label={job.preview.platform.toUpperCase()} size={34} />
+                      </div>
+                    )}
+                    <div className="platform-badge" title={job.preview.platform.toUpperCase()}>
+                      <PlatformIcon platform={job.preview.platform} label={job.preview.platform.toUpperCase()} size={22} />
+                    </div>
+                  </div>
+                )}
+                <div className="row">
+                  <h3>{job.preview?.title ?? job.id}</h3>
+                  <span className="badge">{job.status}</span>
+                </div>
+                <div className="status">Job id: {job.id}</div>
+                {job.preview && (
+                  <div className="status" style={{ marginTop: "4px" }}>
+                    {job.preview.slug} • {job.preview.platform.toUpperCase()}
+                  </div>
+                )}
+                {typeof progress === "number" && (
+                  <div className="progress" style={{ marginTop: "8px" }}>
+                    <span style={{ width: `${Math.min(1, Math.max(0, progress)) * 100}%` }} />
+                  </div>
+                )}
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="card">
+        <div className="row" style={{ marginBottom: "12px" }}>
+          <h3>Ready to play</h3>
+          <span className="status">{libraryItems.length} items</span>
+        </div>
+        <div className="list">
+          {libraryItems.length === 0 && (
+            <div className="status">No games in your library yet. Start a download to fill it.</div>
+          )}
+          {libraryItems.map((item) => (
+            <article className="card" key={item.id}>
+              <div className="row">
+                <div>
+                  <div className="status">
+                    {item.platform ? item.platform.toUpperCase() : "Unknown platform"}
+                  </div>
+                  <h3>{item.gameSlug ?? item.path.split("/").pop()}</h3>
+                </div>
+                <span className="badge">{item.source === "remote" ? "Downloaded" : "Local"}</span>
+              </div>
+              <div className="status">Path: {item.path}</div>
+              <div className="status">Size: {formatSize(item.size)}</div>
+              <div className="status">Updated: {new Date(item.mtime).toLocaleString()}</div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/pages/QueuePage.tsx
+++ b/apps/web/src/pages/QueuePage.tsx
@@ -1,16 +1,9 @@
 import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiGet, API_URL } from "../lib/api";
-import type { JobEvent, JobRecord } from "@crocdesk/shared";
+import type { JobEvent } from "@crocdesk/shared";
 import PlatformIcon from "../components/PlatformIcon";
-
-type JobPreview = {
-  slug: string;
-  title: string;
-  platform: string;
-  boxart_url?: string;
-};
-type JobWithPreview = JobRecord & { preview?: JobPreview };
+import type { JobWithPreview } from "../types";
 
 export default function QueuePage() {
   const queryClient = useQueryClient();

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -1,0 +1,10 @@
+import type { JobRecord } from "@crocdesk/shared";
+
+export type JobPreview = {
+  slug: string;
+  title: string;
+  platform: string;
+  boxart_url?: string;
+};
+
+export type JobWithPreview = JobRecord & { preview?: JobPreview };

--- a/tests/e2e/library.spec.ts
+++ b/tests/e2e/library.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test, Page } from '@playwright/test';
+import { captureOnCI } from './utils';
+
+const jobsPayload = [
+  {
+    id: 'job-library-1',
+    type: 'download_and_install',
+    status: 'running',
+    payload: { slug: 'metroid-nes', profileId: 'default' },
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    preview: {
+      slug: 'metroid-nes',
+      title: 'Metroid',
+      platform: 'nes',
+      boxart_url: 'https://example.com/boxart/metroid.jpg',
+    },
+  },
+];
+
+const libraryItems = [
+  {
+    id: 'lib-1',
+    path: '/games/NES/Metroid',
+    size: 8 * 1024 * 1024,
+    mtime: new Date('2024-01-01T12:00:00Z').getTime(),
+    platform: 'nes',
+    source: 'remote',
+    gameSlug: 'metroid-nes',
+  },
+  {
+    id: 'lib-2',
+    path: '/games/SNES/Zelda',
+    size: 1_234_000,
+    mtime: new Date('2024-02-02T12:00:00Z').getTime(),
+    platform: 'snes',
+    source: 'local',
+    gameSlug: 'zelda-snes',
+  },
+];
+
+function interceptLibrary(page: Page) {
+  page.route('**/jobs', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(jobsPayload) })
+  );
+  page.route('**/library/items', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(libraryItems) })
+  );
+
+  const sse =
+    'data: ' + JSON.stringify({ jobId: 'job-library-1', type: 'JOB_PROGRESS', progress: 0.42, ts: Date.now() }) + '\n\n';
+  page.route('**/events', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/event-stream', body: sse })
+  );
+}
+
+test.describe('Library view', () => {
+  test.beforeEach(async ({ page }) => {
+    interceptLibrary(page);
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Library' }).click();
+  });
+
+  test('shows active downloads with preview art and progress', async ({ page }) => {
+    const downloadCards = page.locator('section:has-text("Downloading") article.card');
+    await expect(downloadCards).toHaveCount(1);
+
+    const downloadCard = downloadCards.first();
+    await expect(downloadCard.getByRole('heading', { name: 'Metroid' })).toBeVisible();
+    await expect(downloadCard.getByText('download_and_install')).toBeVisible();
+    await expect(downloadCard.locator('img.thumb')).toBeVisible();
+    await expect(downloadCard.locator('.platform-badge')).toBeVisible();
+    await expect(downloadCard.locator('div.progress span')).toBeVisible();
+
+    await captureOnCI(page, 'library-downloading');
+  });
+
+  test('lists ready-to-play items with platform and source badges', async ({ page }) => {
+    const readyCards = page.locator('section:has-text("Ready to play") article.card');
+    await expect(readyCards).toHaveCount(2);
+
+    await expect(readyCards.nth(0).getByText('NES', { exact: true })).toBeVisible();
+    await expect(readyCards.nth(0).getByText('Downloaded')).toBeVisible();
+    await expect(readyCards.nth(1).getByText('SNES', { exact: true })).toBeVisible();
+    await expect(readyCards.nth(1).getByText('Local')).toBeVisible();
+
+    await expect(page.getByText('2 items')).toBeVisible();
+    await captureOnCI(page, 'library-ready-items');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Library page that surfaces active downloads and ready-to-play items
- share job preview typing between queue and library views
- wire navigation and routing to the new Library view
- add playwright e2e coverage for the Library view, validating downloading and ready-to-play sections

## Testing
- npm run test:e2e -- --grep "Library view" *(fails: playwright not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947f46646d48328a3e0da523d4b7431)