### PR TITLE
Add nested developer and user guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,40 @@
-# CrocDesk
+# 🐊 Jacare
 
-CrocDesk is a desktop ROM library manager that brings together an Electron shell, an Express API, and a Vite-powered React UI to help you organize, scrape, and launch games from a single experience. It speaks to the hosted [Crocdb](https://crocdb.net) service for search and metadata, then runs jobs locally to keep your library synchronized.
+Jacare (Portuguese for "caiman") is a Brazilian-flavored, croc-tough desktop ROM library manager. It combines an Electron shell, an Express API, and a Vite-powered React UI so you can organize, scrape, and launch games from a single experience—wrapping the hosted [Crocdb](https://crocdb.net) service for search and metadata while running local jobs to keep your library synchronized. 🇧🇷
 
-## Why CrocDesk?
+> Want details? Pick your path:
+> - 📚 **Developer guide:** Head to [`docs/README.md`](docs/README.md) for the full technical rundown.
+> - 😀 **Friendly guide:** Open [`docs/user/README.md`](docs/user/README.md) for a non-technical walkthrough.
+
+## Why Jacare? 🪗🌴
 - **One app for everything:** Browse, enrich, and launch ROMs without juggling separate tools.
 - **Local-first with cloud search:** Metadata is pulled from [Crocdb](https://api.crocdb.net) while your collection, cache, and settings remain on disk.
 - **Built for speed:** Background jobs, SSE updates, and caching cut down on repetitive scraping.
 - **Works online or offline:** Cached search and entry data keep your library usable even when you lose connectivity.
+- **Amazonian attitude:** The Jacare name nods to caimans—lean, mean, and ready to snap up your metadata.
 
-## Project layout
+## Project layout 🗂️
 - `apps/server` – Express API, job orchestration, local scanning, and Crocdb client.
 - `apps/web` – React UI (Vite) served by the server or opened directly in dev.
 - `apps/desktop` – Electron main process wrapping the server and web UI for a native experience.
 - `packages/shared` – Shared types, defaults, and the manifest schema used across workspaces.
 
-## Getting started
-1. **Install dependencies**
+## Getting started 🚀
+1. **Install dependencies** 📦
    ```bash
    npm ci
    ```
-2. **Run everything in development** (shared build watcher + server + web + desktop):
+2. **Run everything in development** (shared build watcher + server + web + desktop) 🔥
    ```bash
    npm run dev
    ```
-3. **Start an individual workspace** if you want to isolate debugging:
+3. **Start an individual workspace** if you want to isolate debugging 🛠️
    ```bash
    npm run dev:server   # Express API + jobs
    npm run dev:web      # React UI with Vite
    npm run dev:desktop  # Electron shell
    ```
-4. **Build or type-check all workspaces** when you are ready to ship:
+4. **Build or type-check all workspaces** when you are ready to ship 📦✅
    ```bash
    npm run build
    npm run typecheck
@@ -37,9 +42,9 @@ CrocDesk is a desktop ROM library manager that brings together an Electron shell
 
 > Tip: The desktop app expects the web dev server at `http://localhost:5173` by default. Override with `CROCDESK_DEV_URL` if you change the Vite port.
 
-## Configuration & data
+## Configuration & data ⚙️
 - **Default port:** `CROCDESK_PORT=3333`.
-- **Data directory:** `CROCDESK_DATA_DIR=./data` holds SQLite databases, cache tables, and manifest files. Customize it to point CrocDesk at a shared drive or fast SSD.
+- **Data directory:** `CROCDESK_DATA_DIR=./data` holds SQLite databases, cache tables, and manifest files. Customize it to point Jacare at a shared drive or fast SSD.
 - **Downloads:** Disabled by default; enable with `CROCDESK_ENABLE_DOWNLOADS=true` to fetch assets or binaries.
 - **Crocdb base URL:** `CROCDB_BASE_URL=https://api.crocdb.net`.
 - **Cache TTL:** `CROCDB_CACHE_TTL_MS=86400000` (24 hours) for search and entry cache tables.
@@ -48,14 +53,14 @@ CrocDesk is a desktop ROM library manager that brings together an Electron shell
 
 Data is stored in SQLite tables for settings, profiles, Crocdb caches, library items, jobs, and job steps. Each scanned folder receives a `.crocdesk.json` manifest describing the game entry.
 
-## Using CrocDesk
+## Using Jacare 🎮
 1. Launch the server (or the desktop app, which starts it for you).
-2. Add a folder containing ROMs; CrocDesk writes `.crocdesk.json` manifests to each folder.
+2. Add a folder containing ROMs; Jacare writes `.crocdesk.json` manifests to each folder.
 3. Trigger a **Scan** job to discover new files. Progress streams through **Server-Sent Events (SSE)** from `GET /events`.
 4. Use **Search** (POST `/search`) to find metadata via Crocdb, then **Entry** (POST `/entry`) to enrich your local manifest.
 5. Launch games directly from the UI or open the manifest to integrate with other launchers.
 
-## API quick reference
+## API quick reference 📡
 - **Base URL:** `http://localhost:<CROCDESK_PORT>` (3333 by default) when running locally, or the packaged server inside Electron.
 - **Endpoints:**
   - `POST /search` – Query Crocdb for matches.
@@ -64,16 +69,16 @@ Data is stored in SQLite tables for settings, profiles, Crocdb caches, library i
   - `GET /events` – SSE stream for job progress (scans, downloads, cache refreshes).
 - **Responses:** Wrapped as `{ info, data }` objects for consistency across the UI and API.
 
-## Running in production
+## Running in production 🏭
 - Use `npm run build` to compile all workspaces, then start the server with the compiled artifacts.
 - Desktop bundles are produced from `apps/desktop` and ship with the server and web assets included.
 - CI builds on the `main` branch automatically publish release archives to GitHub with the latest changelog and README so you can download ready-to-run packages.
 
-## Helpful links
-- CrocDesk issues & roadmap: [GitHub Issues](https://github.com/your-org/crocdesk/issues)
+## Helpful links 🔗
+- Jacare issues & roadmap: [GitHub Issues](https://github.com/your-org/crocdesk/issues)
 - Crocdb service: [https://crocdb.net](https://crocdb.net) and API docs at [https://api.crocdb.net](https://api.crocdb.net)
 - Electron: [https://www.electronjs.org/](https://www.electronjs.org/)
 - Express: [https://expressjs.com/](https://expressjs.com/)
 - React + Vite: [https://vitejs.dev/](https://vitejs.dev/) & [https://react.dev/](https://react.dev/)
 
-If you build on CrocDesk or run into issues, please open a GitHub issue—we're excited to see what you ship!
+If you build on Jacare or run into issues, please open a GitHub issue—we're excited to see what you ship! 🌟

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,82 @@
+# Jacare Developer Guide 🧑‍💻🐊
+
+Welcome to the full technical README for **Jacare**, the Brazilian-inspired desktop ROM library manager that wraps the Crocdb API with an Electron + Express + React stack.
+
+## Table of contents
+- [Project overview](#project-overview)
+- [Architecture](#architecture)
+- [Repository layout](#repository-layout)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Development scripts](#development-scripts)
+- [Configuration](#configuration)
+- [Data & storage](#data--storage)
+- [API quick reference](#api-quick-reference)
+- [Production build](#production-build)
+- [Support](#support)
+
+## Project overview
+Jacare helps you browse, enrich, and launch ROMs from one place. It keeps your library on disk while pulling metadata from [Crocdb](https://crocdb.net) and reporting long-running work through jobs and SSE streams.
+
+## Architecture
+- **Electron shell** boots the server and ships the React UI for a native desktop experience.
+- **Express API** powers Crocdb searches, manifest writing, and job orchestration.
+- **React + Vite UI** calls the API over REST + SSE for real-time job updates.
+- **SQLite backing store** keeps settings, profiles, cached Crocdb responses, library items, and job tracking tables.
+
+## Repository layout
+- `apps/server` – Express API, jobs, local scanning, and Crocdb client.
+- `apps/web` – React UI (Vite) served by the server or opened directly in dev.
+- `apps/desktop` – Electron main process that wraps the server and UI.
+- `packages/shared` – Shared types, defaults, and the manifest schema used across workspaces.
+
+## Prerequisites
+- Node.js 18+
+- npm
+- Optional: Git LFS if you store binaries or media in the repo.
+
+## Installation
+```bash
+npm ci
+```
+
+## Development scripts
+- `npm run dev` – Run shared build watch + server + web + desktop together.
+- `npm run dev:server` – Start the Express API and job runners.
+- `npm run dev:web` – Start the React UI via Vite.
+- `npm run dev:desktop` – Start the Electron shell pointing at the dev server.
+- `npm run build` – Build all workspaces.
+- `npm run typecheck` – Type-check the monorepo.
+
+## Configuration
+- `CROCDESK_PORT` (default `3333`)
+- `CROCDESK_DATA_DIR` (default `./data`)
+- `CROCDESK_ENABLE_DOWNLOADS` (default `false`)
+- `CROCDB_BASE_URL` (default `https://api.crocdb.net`)
+- `CROCDB_CACHE_TTL_MS` (default `86400000`)
+- `VITE_API_URL` (default `http://localhost:3333`)
+- `CROCDESK_DEV_URL` (default `http://localhost:5173`)
+
+## Data & storage
+- SQLite tables: `settings`, `profiles`, `crocdb_cache_search`, `crocdb_cache_entry`, `library_items`, `jobs`, `job_steps`.
+- Each scanned ROM folder receives a `.crocdesk.json` manifest describing the game entry.
+- Data directory defaults to `./data`; point it to a faster disk or network share as needed.
+
+## API quick reference
+- Base URL: `http://localhost:<CROCDESK_PORT>` (3333 by default) or the packaged server inside Electron.
+- Endpoints:
+  - `POST /search` – Query Crocdb for matches.
+  - `POST /entry` – Pull metadata and assets for a specific result.
+  - `GET /platforms` / `GET /regions` / `GET /info` – Reference data for the UI.
+  - `GET /events` – SSE stream for job progress (scans, downloads, cache refreshes).
+- Responses are wrapped as `{ info, data }` objects for consistency.
+
+## Production build
+- Run `npm run build` to compile all workspaces.
+- Package the Electron app from `apps/desktop`; it bundles the server and web assets.
+- CI on `main` can publish release archives with the latest changelog and README.
+
+## Support
+- Issues & roadmap: [GitHub Issues](https://github.com/your-org/crocdesk/issues)
+- Crocdb service: [https://crocdb.net](https://crocdb.net) and [https://api.crocdb.net](https://api.crocdb.net)
+- Tech stack docs: [Electron](https://www.electronjs.org/), [Express](https://expressjs.com/), [Vite](https://vitejs.dev/), [React](https://react.dev/)

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,0 +1,37 @@
+# Jacare Friendly Guide 😀🐊
+
+This guide is for anyone who wants to use Jacare without digging into code. Follow the steps below to organize your ROM collection with minimal setup.
+
+## What is Jacare?
+Jacare is a desktop app that helps you keep your game ROMs tidy. It finds details like cover art and descriptions using the Crocdb online database while storing your library on your computer.
+
+## Quick start
+1. **Install the app**
+   - Download the Jacare desktop package for your system (Windows/macOS/Linux) from the releases page.
+   - Install it like any other app.
+2. **Open Jacare**
+   - Launch the app. The server and the visual interface start automatically.
+3. **Add your ROM folders**
+   - Click **Add Folder** and choose the folders that contain your ROM files.
+   - Jacare writes a small `.crocdesk.json` file inside each folder so it remembers what you added.
+4. **Let Jacare scan**
+   - Hit **Scan** to let Jacare discover the ROMs in your folders. Progress appears in the app.
+5. **Search for game details**
+   - Use **Search** to find matches from Crocdb. When you like a result, pick **Enrich/Entry** to pull cover art and metadata.
+6. **Launch and enjoy**
+   - Launch games directly from Jacare, or open the manifest to plug it into another launcher.
+
+## Staying organized
+- Keep your ROMs in clearly named folders (e.g., `NES/Mario/`).
+- Re-run **Scan** after adding new games so Jacare can index them.
+- If you're offline, you can still browse what was already scanned, and Jacare will use cached results until you reconnect.
+
+## Common questions
+- **Do I need an account?** No—Jacare uses Crocdb without sign-in.
+- **Where does it store data?** In a `data` folder next to the app, including the small `.crocdesk.json` files in each ROM folder.
+- **Can I turn off downloads?** Yes. Downloads are off by default; you can enable them in settings if you want Jacare to fetch assets.
+- **Is my collection safe?** Jacare reads your ROMs and metadata but keeps everything on your device unless you choose to share it.
+
+## Need help?
+- Check for updates on the GitHub releases page.
+- Open an issue on GitHub with details about what went wrong and what you expected.


### PR DESCRIPTION
## Summary
- add a developer-focused README under docs with detailed technical setup and references
- include a user-friendly guide under docs/user for non-technical onboarding
- update the main README to point readers to both guides

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694819226c348328a001eca75c68f095)