### PR TITLE
Add browse sort controls and default to popularity

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,8 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.56",
     "@types/react-dom": "^18.2.19",
     "@vitejs/plugin-react": "^4.2.1",

--- a/apps/web/src/components/__tests__/PlatformIcon.spec.tsx
+++ b/apps/web/src/components/__tests__/PlatformIcon.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import PlatformIcon from '../PlatformIcon';
 
 afterEach(() => cleanup());

--- a/apps/web/src/pages/BrowsePage.tsx
+++ b/apps/web/src/pages/BrowsePage.tsx
@@ -10,10 +10,13 @@ import type {
   CrocdbPlatformsResponseData,
   CrocdbRegionsResponseData,
   CrocdbSearchResponseData,
+  CrocdbSortOption,
   LibraryItem,
   Profile,
   JobEvent
 } from "@crocdesk/shared";
+
+const SORT_OPTIONS: CrocdbSortOption[] = ["popularity", "title"];
 
 export default function BrowsePage() {
   const location = useLocation();
@@ -22,6 +25,7 @@ export default function BrowsePage() {
   const [searchKey, setSearchKey] = useState("");
   const [platform, setPlatform] = useState("");
   const [region, setRegion] = useState("");
+  const [sortBy, setSortBy] = useState<CrocdbSortOption>("popularity");
   const [results, setResults] = useState<CrocdbEntry[]>([]);
   const [status, setStatus] = useState<string>("");
   const [selectedProfileId, setSelectedProfileId] = useState<string>("");
@@ -86,6 +90,7 @@ export default function BrowsePage() {
             searchKey,
             platform,
             region,
+            sortBy,
             selectedProfileId,
             status: `Found ${response.data.total_results} results`,
             results: response.data.results ?? []
@@ -149,9 +154,13 @@ export default function BrowsePage() {
       const q = searchParams.get("q") || undefined;
       const pf = searchParams.get("pf") || undefined;
       const rg = searchParams.get("rg") || undefined;
+      const sort = searchParams.get("sort") || undefined;
       if (q) setSearchKey(q);
       if (pf) setPlatform(pf);
       if (rg) setRegion(rg);
+      if (sort && SORT_OPTIONS.includes(sort as CrocdbSortOption)) {
+        setSortBy(sort as CrocdbSortOption);
+      }
 
       const raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw) {
@@ -159,6 +168,7 @@ export default function BrowsePage() {
           searchKey?: string;
           platform?: string;
           region?: string;
+          sortBy?: string;
           selectedProfileId?: string;
           results?: CrocdbEntry[];
           status?: string;
@@ -166,6 +176,9 @@ export default function BrowsePage() {
         if (!q && saved.searchKey) setSearchKey(saved.searchKey);
         if (!pf && saved.platform) setPlatform(saved.platform);
         if (!rg && saved.region) setRegion(saved.region);
+        if (!sort && saved.sortBy && SORT_OPTIONS.includes(saved.sortBy as CrocdbSortOption)) {
+          setSortBy(saved.sortBy as CrocdbSortOption);
+        }
         if (saved.selectedProfileId) setSelectedProfileId(saved.selectedProfileId);
         if (saved.results && !results.length) setResults(saved.results);
         if (saved.status) setStatus(saved.status);
@@ -185,11 +198,17 @@ export default function BrowsePage() {
     const q = searchParams.get("q") || undefined;
     const pf = searchParams.get("pf") || undefined;
     const rg = searchParams.get("rg") || undefined;
+    const sortParam = searchParams.get("sort");
+    const sort =
+      sortParam && SORT_OPTIONS.includes(sortParam as CrocdbSortOption)
+        ? (sortParam as CrocdbSortOption)
+        : sortBy;
     if ((q || pf || rg) && results.length === 0) {
       searchMutation.mutate({
         search_key: q ?? undefined,
         platforms: pf ? [pf] : undefined,
         regions: rg ? [rg] : undefined,
+        sort_by: sort,
         max_results: 60,
         page: 1
       });
@@ -209,13 +228,14 @@ export default function BrowsePage() {
           searchKey,
           platform,
           region,
+          sortBy,
           selectedProfileId,
           status,
           results
         })
       );
     } catch {}
-  }, [searchKey, platform, region, selectedProfileId, status, results]);
+  }, [searchKey, platform, region, sortBy, selectedProfileId, status, results]);
 
   function handleSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -223,11 +243,13 @@ export default function BrowsePage() {
     if (searchKey) nextParams.q = searchKey;
     if (platform) nextParams.pf = platform;
     if (region) nextParams.rg = region;
+    if (sortBy) nextParams.sort = sortBy;
     setSearchParams(nextParams);
     searchMutation.mutate({
       search_key: searchKey || undefined,
       platforms: platform ? [platform] : undefined,
       regions: region ? [region] : undefined,
+      sort_by: sortBy,
       max_results: 60,
       page: 1
     });
@@ -275,6 +297,17 @@ export default function BrowsePage() {
                     {name}
                   </option>
                 ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="sort-select">Sort</label>
+            <select
+              id="sort-select"
+              value={sortBy}
+              onChange={(event) => setSortBy(event.target.value as CrocdbSortOption)}
+            >
+              <option value="popularity">Popularity</option>
+              <option value="title">Title (A-Z)</option>
             </select>
           </div>
           <div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,8 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.2",
+        "@testing-library/react": "^14.0.0",
         "@types/react": "^18.2.56",
         "@types/react-dom": "^18.2.19",
         "@vitejs/plugin-react": "^4.2.1",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -21,6 +21,8 @@ export type CrocdbEntry = {
   links: CrocdbLink[];
 };
 
+export type CrocdbSortOption = "popularity" | "title";
+
 export type CrocdbSearchRequest = {
   search_key?: string;
   platforms?: string[];
@@ -28,6 +30,7 @@ export type CrocdbSearchRequest = {
   rom_id?: string;
   max_results?: number;
   page?: number;
+  sort_by?: CrocdbSortOption;
 };
 
 export type CrocdbSearchResponseData = {


### PR DESCRIPTION
## Summary
- add sort option support to shared Crocdb search request types
- add a sort selector on the browse page defaulting to popularity and persisting across sessions/URLs
- include the chosen sort option in Crocdb search payloads for manual and automatic queries
- add Testing Library dev dependencies for @crocdesk/web and use Vitest-aware jest-dom typings so typechecks succeed

## Testing
- npm run typecheck


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948204bc1088328b0f93a420b441b45)