### PR TITLE
Add Docker compose template and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Jacare (Portuguese for "caiman") is a Brazilian-flavored, croc-tough desktop ROM
 - `apps/desktop` – Electron main process wrapping the server and web UI for a native experience.
 - `packages/shared` – Shared types, defaults, and the manifest schema used across workspaces.
 
+See [`docker/README.md`](docker/README.md) for a Docker Compose template with platform-specific mount examples.
+
 ## Getting started 🚀
 1. **Install dependencies** 📦
    ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,16 @@
+# Docker Compose template
+
+This folder contains a starter `docker-compose.yml` for running Jacare with bind-mounted data and library directories. Windows paths are enabled by default; macOS and Linux examples are included as comments so you can switch quickly.
+
+## Usage
+1. Adjust the bind mounts in [`docker-compose.yml`](docker-compose.yml) to match your host paths.
+2. (Optional) Uncomment any emulator services you want to run alongside Jacare (RetroArch, Dolphin, PCSX2).
+3. Start the stack:
+   ```bash
+   docker compose -f docker/docker-compose.yml up -d
+   ```
+4. Visit the Jacare web UI at `http://localhost:5173` and API at `http://localhost:3333`.
+
+The template sets `CROCDESK_DATA_DIR` to `/data` and assumes your ROM library is mounted at `/library`. You can also build the server image from the repository by uncommenting the `build` section on the `crocdesk` service.
+
+For broader project context, configuration options, and runtime expectations, see the [root README](../README.md).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,91 @@
+version: "3.9"
+
+services:
+  crocdesk:
+    image: ghcr.io/your-org/crocdesk:latest
+    restart: unless-stopped
+    ports:
+      - "3333:3333" # CrocDesk server/API
+      - "5173:5173" # Web UI (when served separately)
+    environment:
+      CROCDESK_DATA_DIR: /data
+      VITE_API_URL: http://localhost:3333
+      CROCDESK_ENABLE_DOWNLOADS: "false"
+    volumes:
+      # Windows default: bind your data and library folders into the container.
+      - type: bind
+        source: C:/Users/<you>/crocdesk/data
+        target: /data
+      - type: bind
+        source: C:/Users/<you>/crocdesk/library
+        target: /library
+      # macOS example paths:
+      # - type: bind
+      #   source: /Users/<you>/crocdesk/data
+      #   target: /data
+      # - type: bind
+      #   source: /Users/<you>/crocdesk/library
+      #   target: /library
+      # Linux example paths:
+      # - type: bind
+      #   source: /home/<you>/crocdesk/data
+      #   target: /data
+      # - type: bind
+      #   source: /home/<you>/crocdesk/library
+      #   target: /library
+    # Uncomment this block to build from the local repository instead of pulling an image.
+    # build:
+    #   context: ..
+    #   dockerfile: apps/server/Dockerfile
+
+  # Emulator examples (disabled by default). These services expect ROMs under /library
+  # and can be linked via Jacare's launcher settings. Uncomment the services you need
+  # and map any additional ports required by your setup.
+
+  # retroarch:
+  #   image: ghcr.io/libretro/retroarch:latest
+  #   restart: unless-stopped
+  #   volumes:
+  #     - type: bind
+  #       source: C:/Users/<you>/crocdesk/library
+  #       target: /library
+  #     # macOS/Linux examples:
+  #     # - type: bind
+  #     #   source: /Users/<you>/crocdesk/library
+  #     #   target: /library
+  #     # - type: bind
+  #     #   source: /home/<you>/crocdesk/library
+  #     #   target: /library
+  #   command: ["retroarch"]
+
+  # dolphin:
+  #   image: ghcr.io/dolphin-emu/dolphin:latest
+  #   restart: unless-stopped
+  #   volumes:
+  #     - type: bind
+  #       source: C:/Users/<you>/crocdesk/library
+  #       target: /library
+  #   # macOS/Linux examples:
+  #   # - type: bind
+  #   #   source: /Users/<you>/crocdesk/library
+  #   #   target: /library
+  #   # - type: bind
+  #   #   source: /home/<you>/crocdesk/library
+  #   #   target: /library
+  #   command: ["dolphin-emu", "--batch"]
+
+  # pcsx2:
+  #   image: ghcr.io/pcsx2/pcsx2:latest
+  #   restart: unless-stopped
+  #   volumes:
+  #     - type: bind
+  #       source: C:/Users/<you>/crocdesk/library
+  #       target: /library
+  #   # macOS/Linux examples:
+  #   # - type: bind
+  #   #   source: /Users/<you>/crocdesk/library
+  #   #   target: /library
+  #   # - type: bind
+  #   #   source: /home/<you>/crocdesk/library
+  #   #   target: /library
+  #   command: ["pcsx2", "--portable"]


### PR DESCRIPTION
## Summary
- add a docker-compose template with Windows defaults and commented macOS/Linux and emulator examples
- document how to run the compose stack and optional emulator services
- link the new docker documentation from the main README for discoverability

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a480b8448328ace65b96247a15c4)