### PR TITLE
Add platform search to browse page

### DIFF
--- a/apps/web/src/components/SpeedChart.tsx
+++ b/apps/web/src/components/SpeedChart.tsx
@@ -58,7 +58,7 @@ export default function SpeedChart({ speeds, maxBars = 20 }: SpeedChartProps) {
               minWidth: 4,
               height: `${Math.max(height, 4)}%`,
               backgroundColor: "var(--accent)",
-              borderRadius: `${radius.xs} ${radius.xs} 0 0`,
+              borderRadius: `${radius.sm} ${radius.sm} 0 0`,
               transition: `height ${transitions.normal}`
             }}
             title={`${speed.toFixed(2)} MB/s`}


### PR DESCRIPTION
## Summary
- add a platform picker card on the browse page with search filtering and platform badges
- show short platform codes used in library paths alongside platform names and brands
- fix SpeedChart border radius to match available design tokens

## Testing
- npm run typecheck -w @crocdesk/web

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a6310cac8328ab0e7eca09209ac9)