### PR TITLE
Enhance Docker instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,24 @@
 
 ### Option: Run with Docker 
 
-If you’re familiar with Docker, check **[`docker/README.md`](docker/README.md)** for a Docker Compose template, including platform-specific volume/mount examples.
+
+If you’re familiar with [Docker](https://docs.docker.com/get-started/docker-overview/), here's a one-liner to run and test Jacare:
+```
+docker run --rm -p 3333:3333 -v jacare-data:/data -v jacare-library:/library -e CROCDESK_ENABLE_DOWNLOADS=false ghcr.io/luandev/jacare:latest
+```
+- What it does:
+  -  `--rm` - Automatically removes the container when it stops
+  - `-p 3333:3333` - Exposes port 3333 for the web UI
+  - `-v jacare-data:/data` - Creates a named volume for data (persists between runs)
+  - `-v jacare-library:/library` - Creates a named volume for library (persists between runs)
+  - `-e CROCDESK_ENABLE_DOWNLOADS=false` - Disables downloads (default)
+ Uses the pre-built image from GitHub Container Registry
+
+- Access the app:
+Open http://localhost:3333 in your browser.
+- To stop:
+Press Ctrl+C or run docker stop <container-id>.
+- Check **[`docker/README.md`](docker/README.md)** for a Docker Compose template, including platform-specific volume/mount examples.
 
 ### Option: Run locally (Node.js)
 


### PR DESCRIPTION
Added Docker run command and usage instructions to README.

## Summary
- 

## Testing
- 

## Checklist
- [ ] Added a semantic version comment to this PR using `/semver: patch`, `/semver: minor`, or `/semver: major`. ([See template](.github/semver-comment-template.md) for examples)
- [ ] Confirmed workflows and automation updates (if any) have appropriate permissions.
